### PR TITLE
Feature/migrate-ng9: Fix build

### DIFF
--- a/Development Instructions.md
+++ b/Development Instructions.md
@@ -74,7 +74,7 @@ npm run build
 
 To test locally the npm package:
 ```Shell
-npm run pack-lib
+npm run pack:lib
 ```
 Then you can install it in an app to test it:
 ```Shell

--- a/build.js
+++ b/build.js
@@ -44,7 +44,7 @@ if (shell.exec(`node-sass -r ${OUT_DIR} -o ${OUT_DIR}`).code === 0) {
 
 /* AoT compilation */
 shell.echo(`Start AoT compilation`);
-if (shell.exec(`ngc -p ${OUT_DIR}/tsconfig-build.json`).code !== 0) {
+if (shell.exec(`ngc -p ./tsconfig-build.json`).code !== 0) {
   shell.echo(chalk.red(`Error: AoT compilation failed`));
   shell.exit(1);
 }
@@ -71,7 +71,7 @@ if (
 
 shell.echo(`Produce ESM5/FESM5 versions`);
 shell.exec(
-  `ngc -p ${OUT_DIR}/tsconfig-build.json --target es5 -d false --outDir ${OUT_DIR_ESM5_ABS} --sourceMap`
+  `ngc -p ./tsconfig-build.json --target es5 -d false --outDir ${OUT_DIR_ESM5_ABS} --sourceMap`
 );
 shell.cp(
   `-Rf`,


### PR DESCRIPTION
There appeared to be an issue with the paths relating to the ngc compilation.
Also fixed the documented command for local testing.